### PR TITLE
Fix quotation display when using default JsonQuotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ JsonConfig(
     /// your customize configuration
     data: JsonConfigData(
         animation: true,
-        animationDuration: Duration(millseconds: 300),
+        animationDuration: Duration(milliseconds: 300),
         animationCurve: Curves.ease,
         itemPadding: EdgeInsets.only(left: 8),
         color: JsonColorScheme(

--- a/lib/src/models/json_style_scheme.dart
+++ b/lib/src/models/json_style_scheme.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 
 /// JsonQuotation
 class JsonQuotation {
-  /// left qoute
-  final String? leftQuote;
+  /// left quote
+  final String leftQuote;
 
-  /// right qoute
-  final String? rightQuote;
+  /// right quote
+  final String rightQuote;
   const JsonQuotation({
-    this.leftQuote,
-    this.rightQuote,
+    this.leftQuote = '',
+    this.rightQuote = '',
   });
 
   /// left qoute and right qoute are same


### PR DESCRIPTION
Key tiles are not working properly when omitting JsonQuotation config:

<img width="600" alt="Screen Shot 2022-05-15 at 00 44 08" src="https://user-images.githubusercontent.com/7874200/168456550-853e045b-84b9-43d5-9d04-9e8492aba53c.png">

This PR fixes it by not allowing null on quotations and setting empty char as default quotes.